### PR TITLE
Issue #20: Scaffold skeleton views (Map, Deal Detail, Add Deal, Profile, Login)

### DIFF
--- a/LocalDeals/LocalDeals/ContentView.swift
+++ b/LocalDeals/LocalDeals/ContentView.swift
@@ -1,68 +1,17 @@
 //
 //  ContentView.swift
+//  LocalDeals
+//
+//  Kept for backwards compatibility — the app entry point now uses MainTabView.
+//
 
 import SwiftUI
-import MapKit
-
-import SwiftUI
-import MapKit
-
 
 struct ContentView: View {
-
-    @State private var position = MapCameraPosition.region(
-        MKCoordinateRegion(
-            center: CLLocationCoordinate2D(latitude: 36.665389, longitude: -121.811307),
-            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-        )
-    )
-    
-    
-    // prepopulating
-    let sampleDeals = [
-        Deal(
-            title: "$5 Off Margarita Flights",
-            businessName: "The Brass Tap",
-            description: "$5 off margarita flights",
-            expiration: "Every Monday",
-            coordinate: CLLocationCoordinate2D(
-                latitude: 36.664856, // marina location
-                longitude: -121.811935
-            )
-        )
-    ]
-
-
     var body: some View {
-            Map(position: $position) {
-                ForEach(sampleDeals) { deal in
-                    Annotation(deal.businessName, coordinate: deal.coordinate) {
-                        VStack(spacing: 2) {
-
-                            Text(deal.title)
-                                .font(.caption2)
-                            
-                            Text(deal.businessName)
-                                .font(.caption2)
-                                .bold()
-                            Text(deal.expiration)
-                                .font(.caption2)
-                                .foregroundColor(.gray)
-
-                            Image(systemName: "mappin.circle.fill")
-                                .foregroundColor(.red)
-                                .font(.title)
-                        }
-                        .padding(5)
-                        .background(Color.white)
-                        .cornerRadius(6)
-                    }
-                }
-            }
-            .ignoresSafeArea()
+        MainTabView()
     }
 }
-
 
 #Preview {
     ContentView()

--- a/LocalDeals/LocalDeals/LocalDealsApp.swift
+++ b/LocalDeals/LocalDeals/LocalDealsApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct LocalDealsApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainTabView()
         }
     }
 }

--- a/LocalDeals/LocalDeals/Views/AddDealView.swift
+++ b/LocalDeals/LocalDeals/Views/AddDealView.swift
@@ -1,0 +1,68 @@
+//
+//  AddDealView.swift
+//  LocalDeals
+//
+//  Empty form for submitting a new deal — title, description, location, expiration.
+//
+
+import SwiftUI
+
+struct AddDealView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var title: String = ""
+    @State private var description: String = ""
+    @State private var locationText: String = ""
+    @State private var expiration: Date = Date()
+    @State private var discountType: String = "Percent Off"
+
+    private let discountTypes = ["Percent Off", "Dollar Off", "BOGO", "Other"]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Deal Info") {
+                    TextField("Title (e.g. $5 Off Margarita Flights)", text: $title)
+                    TextField("Description", text: $description, axis: .vertical)
+                        .lineLimit(3...6)
+                }
+
+                Section("Location") {
+                    TextField("Address or business name", text: $locationText)
+                    // TODO: replace with map picker / GPS
+                    Button(action: { /* TODO: open map picker */ }) {
+                        Label("Pick on Map", systemImage: "map")
+                    }
+                }
+
+                Section("Discount") {
+                    Picker("Type", selection: $discountType) {
+                        ForEach(discountTypes, id: \.self) { Text($0) }
+                    }
+                }
+
+                Section("Expiration") {
+                    DatePicker("Expires", selection: $expiration, displayedComponents: .date)
+                }
+            }
+            .navigationTitle("Add Deal")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Submit") {
+                        // TODO: submit to backend (#6)
+                        dismiss()
+                    }
+                    .disabled(title.isEmpty)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    AddDealView()
+}

--- a/LocalDeals/LocalDeals/Views/DealDetailView.swift
+++ b/LocalDeals/LocalDeals/Views/DealDetailView.swift
@@ -1,0 +1,73 @@
+//
+//  DealDetailView.swift
+//  LocalDeals
+//
+//  Placeholder card layout showing store name, discount, and expiration.
+//
+
+import SwiftUI
+import CoreLocation
+
+struct DealDetailView: View {
+    let deal: Deal
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                    // Discount / title — visually prioritized
+                    Text(deal.title)
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+
+                    // Store name
+                    Label(deal.businessName, systemImage: "storefront")
+                        .font(.title3)
+                        .foregroundColor(.secondary)
+
+                    Divider()
+
+                    // Expiration
+                    Label(deal.expiration, systemImage: "clock")
+                        .font(.subheadline)
+
+                    // Distance / ETA placeholder (TODO: wire up location services)
+                    Label("— mi away · — min drive", systemImage: "location")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    Divider()
+
+                    // Description
+                    Text("Details")
+                        .font(.headline)
+                    Text(deal.description.isEmpty ? "No additional details." : deal.description)
+                        .font(.body)
+
+                    Spacer(minLength: 20)
+
+                    // Save / bookmark placeholder (TODO: #12)
+                    Button(action: { /* TODO: save deal */ }) {
+                        Label("Save Deal", systemImage: "bookmark")
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.accentColor.opacity(0.15))
+                            .foregroundColor(.accentColor)
+                            .cornerRadius(10)
+                    }
+            }
+            .padding()
+        }
+        .navigationTitle("Deal Details")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    DealDetailView(deal: Deal(
+        title: "$5 Off Margarita Flights",
+        businessName: "The Brass Tap",
+        description: "$5 off margarita flights every Monday night.",
+        expiration: "Every Monday",
+        coordinate: CLLocationCoordinate2D(latitude: 36.664856, longitude: -121.811935)
+    ))
+}

--- a/LocalDeals/LocalDeals/Views/LoginView.swift
+++ b/LocalDeals/LocalDeals/Views/LoginView.swift
@@ -1,0 +1,69 @@
+//
+//  LoginView.swift
+//  LocalDeals
+//
+//  Basic email/password fields and submit button (placeholder).
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var isRegisterMode: Bool = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(isRegisterMode ? "Create Account" : "Sign In")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .padding(.top, 40)
+
+            VStack(spacing: 12) {
+                TextField("Email", text: $email)
+                    .textContentType(.emailAddress)
+                    .keyboardType(.emailAddress)
+                    .autocapitalization(.none)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(10)
+
+                SecureField("Password", text: $password)
+                    .textContentType(isRegisterMode ? .newPassword : .password)
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .cornerRadius(10)
+            }
+            .padding(.horizontal)
+
+            Button(action: {
+                // TODO: hook into Firebase Auth (#16, #19)
+            }) {
+                Text(isRegisterMode ? "Register" : "Sign In")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.accentColor)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+            .padding(.horizontal)
+            .disabled(email.isEmpty || password.isEmpty)
+
+            Button(action: { isRegisterMode.toggle() }) {
+                Text(isRegisterMode
+                     ? "Already have an account? Sign In"
+                     : "New here? Create an account")
+                    .font(.footnote)
+            }
+
+            Spacer()
+        }
+        .navigationTitle(isRegisterMode ? "Register" : "Sign In")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack { LoginView() }
+}

--- a/LocalDeals/LocalDeals/Views/MainTabView.swift
+++ b/LocalDeals/LocalDeals/Views/MainTabView.swift
@@ -1,0 +1,33 @@
+//
+//  MainTabView.swift
+//  LocalDeals
+//
+//  Root tab navigation for the app.
+//
+
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            MapView()
+                .tabItem {
+                    Label("Map", systemImage: "map")
+                }
+
+            AddDealView()
+                .tabItem {
+                    Label("Add Deal", systemImage: "plus.circle")
+                }
+
+            ProfileView()
+                .tabItem {
+                    Label("Profile", systemImage: "person.circle")
+                }
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+}

--- a/LocalDeals/LocalDeals/Views/MapView.swift
+++ b/LocalDeals/LocalDeals/Views/MapView.swift
@@ -1,0 +1,76 @@
+//
+//  MapView.swift
+//  LocalDeals
+//
+//  Map (Home) screen — empty map view with "+Add Deal" button placeholder.
+//
+
+import SwiftUI
+import MapKit
+
+struct MapView: View {
+    @State private var position = MapCameraPosition.region(
+        MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 36.665389, longitude: -121.811307),
+            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        )
+    )
+
+    @State private var showAddDeal = false
+    @State private var selectedDeal: Deal?
+
+    // TODO: Replace with deals fetched from backend (#6, #16, #17)
+    let sampleDeals: [Deal] = [
+        Deal(
+            title: "$5 Off Margarita Flights",
+            businessName: "The Brass Tap",
+            description: "$5 off margarita flights",
+            expiration: "Every Monday",
+            coordinate: CLLocationCoordinate2D(latitude: 36.664856, longitude: -121.811935)
+        )
+    ]
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .bottomTrailing) {
+                Map(position: $position) {
+                    ForEach(sampleDeals) { deal in
+                        Annotation(deal.businessName, coordinate: deal.coordinate) {
+                            Image(systemName: "mappin.circle.fill")
+                                .foregroundColor(.red)
+                                .font(.title)
+                                .onTapGesture {
+                                    selectedDeal = deal
+                                }
+                        }
+                    }
+                }
+                .ignoresSafeArea(edges: .bottom)
+
+                Button(action: { showAddDeal = true }) {
+                    Label("Add Deal", systemImage: "plus")
+                        .font(.headline)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .background(Color.accentColor)
+                        .foregroundColor(.white)
+                        .clipShape(Capsule())
+                        .shadow(radius: 4)
+                }
+                .padding()
+            }
+            .navigationTitle("Local Deals")
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showAddDeal) {
+                AddDealView()
+            }
+            .sheet(item: $selectedDeal) { deal in
+                DealDetailView(deal: deal)
+            }
+        }
+    }
+}
+
+#Preview {
+    MapView()
+}

--- a/LocalDeals/LocalDeals/Views/ProfileView.swift
+++ b/LocalDeals/LocalDeals/Views/ProfileView.swift
@@ -1,0 +1,70 @@
+//
+//  ProfileView.swift
+//  LocalDeals
+//
+//  Placeholder lists for saved deals and submitted deals.
+//
+
+import SwiftUI
+
+struct ProfileView: View {
+    // TODO: wire up to authenticated user (#11, #19) and saved/submitted deals (#12)
+    @State private var savedDeals: [Deal] = []
+    @State private var submittedDeals: [Deal] = []
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Saved Deals") {
+                    if savedDeals.isEmpty {
+                        Text("No saved deals yet.")
+                            .foregroundColor(.secondary)
+                            .font(.subheadline)
+                    } else {
+                        ForEach(savedDeals) { deal in
+                            NavigationLink(destination: DealDetailView(deal: deal)) {
+                                DealRow(deal: deal)
+                            }
+                        }
+                    }
+                }
+
+                Section("Submitted Deals") {
+                    if submittedDeals.isEmpty {
+                        Text("You haven't submitted any deals yet.")
+                            .foregroundColor(.secondary)
+                            .font(.subheadline)
+                    } else {
+                        ForEach(submittedDeals) { deal in
+                            NavigationLink(destination: DealDetailView(deal: deal)) {
+                                DealRow(deal: deal)
+                            }
+                        }
+                    }
+                }
+
+                Section {
+                    NavigationLink("Sign In / Register") {
+                        LoginView()
+                    }
+                }
+            }
+            .navigationTitle("Profile")
+        }
+    }
+}
+
+private struct DealRow: View {
+    let deal: Deal
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(deal.title).font(.headline)
+            Text(deal.businessName).font(.subheadline).foregroundColor(.secondary)
+            Text(deal.expiration).font(.caption).foregroundColor(.secondary)
+        }
+    }
+}
+
+#Preview {
+    ProfileView()
+}


### PR DESCRIPTION
Closes #20.

  Scaffolds skeleton SwiftUI views and wires them into a tab-based navigation:

  - `MainTabView` — root `TabView` with Map, Add Deal, and Profile tabs
  - `MapView` — placeholder `Map` with deal-detail navigation
  - `DealDetailView` — placeholder for deal information
  - `AddDealView` — form skeleton for posting a new deal
  - `ProfileView` — profile skeleton with link to login
  - `LoginView` — login/register skeleton
  - Wires `LocalDealsApp` entry point to `MainTabView`

  Each view is split into its own commit for easier review.