### PR TITLE
Fix Cancel button and wire up Save Deal with local persistence

### DIFF
--- a/LocalDeals/LocalDeals/DealManager.swift
+++ b/LocalDeals/LocalDeals/DealManager.swift
@@ -5,15 +5,36 @@ import Observation
 @Observable
 class DealManager {
     var deals: [Deal] = []
+    private(set) var savedDealIDs: Set<String>
 
     private let database = Firestore.firestore()
+    private let savedDealsKey = "savedDealIDs"
+
+    var savedDeals: [Deal] {
+        deals.filter { savedDealIDs.contains($0.id) }
+    }
 
     init(isMocked: Bool = false) {
+        let stored = UserDefaults.standard.stringArray(forKey: "savedDealIDs") ?? []
+        savedDealIDs = Set(stored)
         if isMocked {
             deals = Deal.mockedDeals
         } else {
             getDeals()
         }
+    }
+
+    func isSaved(_ deal: Deal) -> Bool {
+        savedDealIDs.contains(deal.id)
+    }
+
+    func toggleSave(_ deal: Deal) {
+        if savedDealIDs.contains(deal.id) {
+            savedDealIDs.remove(deal.id)
+        } else {
+            savedDealIDs.insert(deal.id)
+        }
+        UserDefaults.standard.set(Array(savedDealIDs), forKey: savedDealsKey)
     }
 
     func getDeals() {

--- a/LocalDeals/LocalDeals/Views/AddDealView.swift
+++ b/LocalDeals/LocalDeals/Views/AddDealView.swift
@@ -26,6 +26,18 @@ struct AddDealView: View {
 
     private let discountTypes = ["Percent Off", "Dollar Off", "BOGO", "Other"]
 
+    private func resetForm() {
+        title = ""
+        businessName = ""
+        description = ""
+        latitudeText = ""
+        longitudeText = ""
+        expiration = Date()
+        discountType = "Percent Off"
+        imageUrl = ""
+        selectedCoordinate = nil
+    }
+
     var body: some View {
         NavigationStack {
             Form {
@@ -74,7 +86,10 @@ struct AddDealView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
+                    Button("Cancel") {
+                        resetForm()
+                        dismiss()
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Submit") {
@@ -97,6 +112,7 @@ struct AddDealView: View {
                             longitude: longitude
                         )
 
+                        resetForm()
                         dismiss()
                     }
                     .disabled(

--- a/LocalDeals/LocalDeals/Views/DealDetailView.swift
+++ b/LocalDeals/LocalDeals/Views/DealDetailView.swift
@@ -10,6 +10,7 @@ import FirebaseFirestore
 
 struct DealDetailView: View {
     let deal: Deal
+    @Environment(DealManager.self) var dealManager
 
     private var formattedExpiration: String {
         deal.expiration.formatted(date: .abbreviated, time: .omitted)
@@ -48,13 +49,16 @@ struct DealDetailView: View {
 
                 Spacer(minLength: 20)
 
-                Button(action: { /* TODO: save deal */ }) {
-                    Label("Save Deal", systemImage: "bookmark")
+                Button(action: { dealManager.toggleSave(deal) }) {
+                    let saved = dealManager.isSaved(deal)
+                    Label(saved ? "Saved" : "Save Deal",
+                          systemImage: saved ? "bookmark.fill" : "bookmark")
                         .frame(maxWidth: .infinity)
                         .padding()
-                        .background(Color.accentColor.opacity(0.15))
+                        .background(Color.accentColor.opacity(saved ? 0.25 : 0.15))
                         .foregroundColor(.accentColor)
                         .cornerRadius(10)
+                        .animation(.easeInOut(duration: 0.2), value: saved)
                 }
             }
             .padding()
@@ -78,4 +82,5 @@ struct DealDetailView: View {
             votes: 0
         )
     )
+    .environment(DealManager(isMocked: true))
 }

--- a/LocalDeals/LocalDeals/Views/ProfileView.swift
+++ b/LocalDeals/LocalDeals/Views/ProfileView.swift
@@ -3,8 +3,7 @@ import SwiftUI
 struct ProfileView: View {
     @Environment(DealManager.self) var dealManager
 
-    var savedDeals: [Deal] = []
-    var submittedDeals: [Deal] = []
+    var savedDeals: [Deal] { dealManager.savedDeals }
 
     var body: some View {
         NavigationStack {


### PR DESCRIPTION
## Summary
- Fixes #30 — Cancel in `AddDealView` called `dismiss()` which is a no-op when the view is a tab in `TabView`. Added `resetForm()` to both Cancel and Submit so the form clears in both contexts; `dismiss()` still fires when the view is a sheet.
- Fixes #34 — Save Deal button had an empty action. `DealManager` now tracks saved deal IDs in `UserDefaults` (`toggleSave`, `isSaved`, `savedDeals`). The button in `DealDetailView` toggles between outline and filled bookmark with a label change. `ProfileView.savedDeals` is now a computed property from `dealManager.savedDeals` so the Profile tab reflects saves immediately. Firestore user-scoped persistence can replace `UserDefaults` once auth (#35) lands.

## Commits
- `Fix Cancel button clearing form when AddDealView is a tab (closes #30)`
- `Add savedDealIDs, toggleSave, and savedDeals to DealManager`
- `Wire Save Deal button in DealDetailView; connect ProfileView saved list (closes #34)`

## Test plan
- [ ] Open Add Deal tab, fill fields, tap Cancel — form should clear
- [ ] Open Add Deal tab, fill fields, tap Submit — deal saves to Firestore and form clears
- [ ] Open Add Deal as sheet from Map → Cancel/Submit should dismiss the sheet
- [ ] Tap a deal pin → tap "Save Deal" → button shows filled bookmark and "Saved"
- [ ] Tap again → button reverts to outline "Save Deal"
- [ ] Kill and reopen the app → previously saved deals are still saved (UserDefaults)
- [ ] Profile tab → Saved Deals section shows deals you bookmarked

🤖 Generated with [Claude Code](https://claude.com/claude-code)